### PR TITLE
Support field resolvers, model path prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 install:
 	go install github.com/gogo/protobuf/protoc-gen-gogo
 	protoc --gogo_out=paths=source_relative,Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor:./pb \
-    	-I=${GOPATH}/pkg/mod/ -I=./pb ./pb/*.proto
+	-I=${GOPATH}/pkg/mod/ -I=/usr/local/include -I=./pb ./pb/*.proto
 	go install ./protoc-gen-gql
 	go install ./protoc-gen-gogqlgen
 	go install ./protoc-gen-gqlgencfg
@@ -14,4 +14,4 @@ example:
 	--gqlgencfg_out=paths=source_relative:. \
 	--gql_out=svcdir=true,paths=source_relative:. \
 	--gogqlgen_out=paths=source_relative,gogoimport=false:. \
-	-I=. -I=./example/ ./example/*.proto
+	-I=. -I=/usr/local/include -I=./example/ ./example/*.proto

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/danielvladco/go-proto-gql
 
+go 1.14
+
 require (
 	github.com/danielvladco/go-proto-gql/pb v0.6.0
 	github.com/gogo/protobuf v1.2.1

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -232,7 +232,9 @@ func (p *Plugin) createOneofFromParent(name string, parent *Type, callstack Call
 	oneofName := ""
 	for _, typeName := range callstack.List() {
 		oneofName += "."
-		oneofName += objects[typeName].DescriptorProto.GetName()
+		if objects[typeName] != nil {
+			oneofName += objects[typeName].DescriptorProto.GetName()
+		}
 	}
 
 	// the name of the generated type


### PR DESCRIPTION
Three changes:

1. Generate field resolvers if proto field has `gqlgencfg:resolve` tag
2. Allow generating models with paths different than source
3. Fix for NPE if a proto has a map of oneof