### PR TITLE
Register Queries in Registry

### DIFF
--- a/pkg/generator/registry.go
+++ b/pkg/generator/registry.go
@@ -22,6 +22,9 @@ func NewRegistry(files SchemaDescriptorList) Registry {
 		gqlFieldsByName: map[desc.Descriptor]map[string]*desc.FieldDescriptor{},
 	}
 	for _, f := range files {
+		for _, m := range f.GetQuery().Methods() {
+			v.methodsByName[m.Name] = m.MethodDescriptor
+		}
 		for _, m := range f.GetMutation().Methods() {
 			v.methodsByName[m.Name] = m.MethodDescriptor
 		}


### PR DESCRIPTION
- Currently, you get a `WARNING Network Error: method not found` for queries but not for mutations.
- After testing locally, I think this is because mutations are added to the registry but queries are not.